### PR TITLE
fix(plugin): throw an explicit error message if service id is missing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,18 @@ type Props = {
   debug?: boolean;
 };
 
+const validateOptions = (options: Props) => {
+  if (!options.services) {
+    throw new Error('Please provide correct services configuration');
+  }
+  if (options.services.some((service) => !service.id)) {
+    throw new Error('The service id is required. please provide a service id');
+  }
+  if (options.services.some((service) => !service.path)) {
+    throw new Error('The service path is required. please provide the path to specification file');
+  }
+};
+
 export default async (_: any, options: Props) => {
   if (!process.env.PROJECT_DIR) {
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
@@ -37,6 +49,7 @@ export default async (_: any, options: Props) => {
   } = utils(process.env.PROJECT_DIR);
 
   const services = options.services ?? [];
+  validateOptions(options);
   for (const serviceSpec of services) {
     console.log(chalk.green(`Processing ${serviceSpec.path}`));
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -510,6 +510,33 @@ describe('OpenAPI EventCatalog Plugin', () => {
 
             expect(service).toBeDefined();
           });
+
+          it('[id] if the `id` not provided in the service config options, The generator throw an explicit error', async () => {
+            await expect(
+              plugin(config, {
+                services: [
+                  {
+                    path: join(openAPIExamples, 'petstore.yml'),
+                  } as any,
+                ],
+              })
+            ).rejects.toThrow('The service id is required');
+          });
+          it('[services] if the `services` not provided in options, The generator throw an explicit error', async () => {
+            await expect(plugin(config, {} as any)).rejects.toThrow('Please provide correct services configuration');
+          });
+          it('[path] if the `path` not provided in service config options, The generator throw an explicit error', async () => {
+            await expect(
+              plugin(config, {
+                services: [
+                  {
+                    name: 'Awesome account service',
+                    id: 'awsome-service',
+                  } as any,
+                ],
+              })
+            ).rejects.toThrow('The service path is required. please provide the path to specification file');
+          });
         });
       });
     });


### PR DESCRIPTION
## Motivation
When integrating multiple specs some services are event producers some event consumers , some send commands some receive commands.

Given the above explanation, in reality, a command contract is owned by the receiving service but sent by the upstream service, in the other side an event contract is owned by the producer service but received by the downstream service. 

When integrating multiple specs, if the generator finds a received event already created by the event owner spec, it will overwrite it. If that event version is already versioned (not latest ) by owner service, the SDK throws an error. 

```yaml
Service A > Sends Event A1 > Sends  EventA2
Service B > Receives Event A1
```
The variety of situations makes it hard to find a convention to automate only based on asyncapi spec.

The PR introduces a declarative way to skip external message creation or modifications using asyncapi extensions `x-eventcatalog-visibility`.

