### PR TITLE
fix(plugin): set default value for plugin DIR

### DIFF
--- a/.changeset/eight-monkeys-wait.md
+++ b/.changeset/eight-monkeys-wait.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-openapi": patch
+---
+
+fix(plugin): set default value for plugin DIR

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ type Props = {
 
 export default async (_: any, options: Props) => {
   if (!process.env.PROJECT_DIR) {
+    process.env.PROJECT_DIR = process.cwd();
+  }
+
+  if (!process.env.PROJECT_DIR) {
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
   }
 


### PR DESCRIPTION
EventCatalog had some core changes, the PROJECT_DIR is now optional. This defaults the value to the current working directory if its not set (which will be catalog directory).